### PR TITLE
Drop Ruby 2.4 and make CI simpler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,8 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.4
-          - 2.5
-          - 2.6
+          - '2.5'
+          - '2.6'
         gemfile:
           - rails4.2
           - rails5.0
@@ -18,17 +17,27 @@ jobs:
           - rails5.2
           - rails6.0
           - rails6.1
-        exclude:
-          - ruby-version: 2.4
-            gemfile: rails6.0
-          - ruby-version: 2.4
-            gemfile: rails6.1
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - uses: zendesk/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - run: bundle exec rake test
+
+  specs_successful:
+    name: Specs passing?
+    needs: specs
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if ${{ needs.specs.result == 'success' }}
+          then
+            echo "All specs pass"
+          else
+            echo "Some specs failed"
+            false
+          fi

--- a/migration_tools.gemspec
+++ b/migration_tools.gemspec
@@ -7,6 +7,8 @@ Gem::Specification.new "migration_tools", "1.7.0" do |s|
   s.files = `git ls-files lib`.split("\n")
   s.license = "Apache-2.0"
 
+  s.required_ruby_version = '>= 2.5.0'
+
   s.add_runtime_dependency "activerecord", '>= 4.2.0', '< 6.2'
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Configuring GitHub to have many required tests is hard to maintain.

In fact, the admin needs to duplicate what is defined in the actions.yml test matrix. It should be quite a bit easier this way, just having one CI job that depends on the success of the entire test matrix.