### PR TITLE
Rails main testing

### DIFF
--- a/.github/workflows/rails_main_testing.yml
+++ b/.github/workflows/rails_main_testing.yml
@@ -1,0 +1,26 @@
+name: Test against Rails main
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at 00:00 UTC
+  workflow_dispatch:
+  push:
+
+jobs:
+  specs:
+    name: Ruby${{ matrix.ruby }} rails_main test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.3'
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails_main.gemfile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake test

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pkg
 mkmf.log
 .bundle/config
 .bundle/environment.rb
+/gemfiles/rails_main.gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     migration_tools (1.9.0)
-      activerecord (>= 6.0.0, < 7.2)
+      activerecord (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    migration_tools (1.9.0)
+    migration_tools (1.10.0)
       activerecord (>= 6.0.0)
 
 GEM

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    migration_tools (1.9.0)
+    migration_tools (1.10.0)
       activerecord (>= 6.0.0)
 
 GEM

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     migration_tools (1.9.0)
-      activerecord (>= 6.0.0, < 7.2)
+      activerecord (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    migration_tools (1.9.0)
+    migration_tools (1.10.0)
       activerecord (>= 6.0.0)
 
 GEM

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     migration_tools (1.9.0)
-      activerecord (>= 6.0.0, < 7.2)
+      activerecord (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    migration_tools (1.9.0)
+    migration_tools (1.10.0)
       activerecord (>= 6.0.0)
 
 GEM

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     migration_tools (1.9.0)
-      activerecord (>= 6.0.0, < 7.2)
+      activerecord (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    migration_tools (1.9.0)
+    migration_tools (1.10.0)
       activerecord (>= 6.0.0)
 
 GEM

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     migration_tools (1.9.0)
-      activerecord (>= 6.0.0, < 7.2)
+      activerecord (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activerecord", github: "rails/rails", branch: "main"
+gem "sqlite3", "~> 1.4"
+
+gemspec path: ".."

--- a/lib/migration_tools/tasks.rb
+++ b/lib/migration_tools/tasks.rb
@@ -28,10 +28,15 @@ module MigrationTools
     end
 
     def migrator(target_version = nil)
-      if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+      if ActiveRecord::VERSION::MAJOR == 7 && ActiveRecord::VERSION::MINOR == 1
         migrate_up(ActiveRecord::MigrationContext.new(
           migrations_paths,
           ActiveRecord::Base.connection.schema_migration
+        ).migrations, target_version)
+      elsif ActiveRecord.gem_version >= Gem::Version.new("7.2")
+        migrate_up(ActiveRecord::MigrationContext.new(
+          migrations_paths,
+          ActiveRecord::Base.connection_pool.schema_migration
         ).migrations, target_version)
       else
         migrate_up(ActiveRecord::MigrationContext.new(
@@ -42,10 +47,15 @@ module MigrationTools
     end
 
     def migrate_up(migrations, target_version)
-      if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+      if ActiveRecord::VERSION::MAJOR == 7 && ActiveRecord::VERSION::MINOR == 1
         ActiveRecord::Migrator.new(:up, migrations,
           ActiveRecord::Base.connection.schema_migration,
           ActiveRecord::Base.connection.internal_metadata,
+          target_version)
+      elsif ActiveRecord.gem_version >= Gem::Version.new("7.2")
+        ActiveRecord::Migrator.new(:up, migrations,
+          ActiveRecord::Base.connection_pool.schema_migration,
+          ActiveRecord::Base.connection_pool.internal_metadata,
           target_version)
       else
         ActiveRecord::Migrator.new(:up, migrations, ActiveRecord::SchemaMigration, target_version)

--- a/migration_tools.gemspec
+++ b/migration_tools.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new "migration_tools", "1.9.0" do |s|
 
   s.required_ruby_version = ">= 2.7.0"
 
-  s.add_runtime_dependency "activerecord", ">= 6.0.0", "< 7.2"
+  s.add_runtime_dependency "activerecord", ">= 6.0.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "bump"

--- a/migration_tools.gemspec
+++ b/migration_tools.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "migration_tools", "1.9.0" do |s|
+Gem::Specification.new "migration_tools", "1.10.0" do |s|
   s.description = "Rake tasks for Rails that add groups to migrations"
   s.summary = "Encourage migrations that do not require downtime"
   s.homepage = "https://github.com/zendesk/migration_tools"


### PR DESCRIPTION
This PR removes the upper boundary on the rails requirement. It is done for the purpose of creating a workflow that tests the library with the current version of rails. 
After having done that, it turned out that in the new versions of ActiveRecord some methods had been relocated from ActiveRecord::ConnectionAdapters::AbstractAdapter to ActiveRecord::ConnectionAdapters::ConnectionPool https://github.com/rails/rails/commit/a91839497412cb904a0991d011b6e921e1711be5